### PR TITLE
Fix CRABS_DOWNLOAD

### DIFF
--- a/subworkflows/local/amplicon_workflow.nf
+++ b/subworkflows/local/amplicon_workflow.nf
@@ -21,7 +21,10 @@ workflow AMPLICON_WORKFLOW {
     // MODULE: Run Crabs db_download if user doesn't have a reference database
     //
     if ( !params.fasta ) {
-        CRABS_DBDOWNLOAD()
+        CRABS_DBDOWNLOAD(
+            params.amplicon_ncbi_db ?: [],
+            params.amplicon_embl_db ?: [],
+            params.amplicon_bold_db ?: [])
         ch_versions = ch_versions.mix(CRABS_DBDOWNLOAD.out.versions)
         ch_ref_fasta = CRABS_DBDOWNLOAD.out.fasta
             .map {


### PR DESCRIPTION
Fixes
```
Process `NFCORE_READSIMULATOR:READSIMULATOR:AMPLICON_WORKFLOW:CRABS_DBDOWNLOAD` declares 3 input channels but 0 were specified

 -- Check script '/home/daniel/.nextflow/assets/nf-core/readsimulator/./workflows/../subworkflows/local/amplicon_workflow.nf' at line: 24 or see '.nextflow.log' file for more details
```
when using `--amplicon_bold_db`


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/readsimulator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/readsimulator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
